### PR TITLE
Fix for allowing to test multiple users with one password

### DIFF
--- a/cme/connection.py
+++ b/cme/connection.py
@@ -341,6 +341,12 @@ class connection(object):
                     secret.append(aesKey)
                     cred_type.append('aesKey')
 
+        # Allow trying multiple users with a single password
+        if len(username) > 1 and len(secret) == 1:
+            secret = secret * len(username)
+            cred_type = cred_type * len(username)
+            self.args.no_bruteforce = True
+
         return domain, username, owned, secret, cred_type, [None] * len(secret)
 
     def try_credentials(self, domain, username, owned, secret, cred_type, data=None):


### PR DESCRIPTION
Before: `cme smb 10.10.10.10 -u userlist.txt -p 1234` was not possible because username list and password list must be equal in non bruteforcing
Now: `cme smb 10.10.10.10 -u userlist.txt -p 1234` fixing that so you can test multiple users with one password
